### PR TITLE
Update to grakn 1.4.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ The ability to write our own domain-specific ontologies lets us quickly experime
 While the end game for PM is to eliminate the need for human-written queries, the fact is we're starting from square one. Which means hand-jamming a lot queries to model the patterns human vulnerability researchers look for when bug hunting.
 
 ## Dependencies
-Paper Machete requires [BinaryNinja v1.1](https://binary.ninja), [Grakn v1.0.0](https://github.com/graknlabs/grakn/releases/tag/v1.0.0), the [Grakn Python Driver](http://github.com/graknlabs/grakn-python), and the [Java JRE](http://www.oracle.com/technetwork/java/javase/downloads/index.html)
+Paper Machete requires [BinaryNinja v1.1](https://binary.ninja), [Grakn v1.4.2]2https://github.com/graknlabs/grakn/releases/tag/v1.4.2), the [Grakn Python Driver](http://github.com/graknlabs/grakn-python), and the [Java JRE](http://www.oracle.com/technetwork/java/javase/downloads/index.html)
 
 
 ## Query Scripts

--- a/queries/cwe_120_v1.py
+++ b/queries/cwe_120_v1.py
@@ -2,15 +2,15 @@
 # CWE-120: Buffer Copy without Checking Size of Input
 #
 # Vuln Info: A trivial way to cause this vulnerability is using the gets() function which is not secure.
-# Ex: 
+# Ex:
 #     bytes_received = gets(input);                                 <--Bad
 #     bytes_received = receive_until(input, sizeof(input), '\n');   <--Good
 #
-# Methodology: 
-# 1. Find gets instruction 
+# Methodology:
+# 1. Find gets instruction
 # 2. There's a vulnerability
 #
-# Try it on: REMATCH_1--Hat_Trick--Morris_Worm 
+# Try it on: REMATCH_1--Hat_Trick--Morris_Worm
 #
 #============================================================================================================
 
@@ -18,25 +18,26 @@ import sys
 import grakn
 
 def main(keyspace):
-    graph = grakn.Client(uri='http://localhost:4567', keyspace=keyspace)
-
-    # Check for gets() function
-    # Get address of function to use for next query
-    function_name = 'gets'
-    query1 = 'match $func isa function, has func-name contains "{}", has asm-address $a; get $a;'.format(function_name)
-    result1 = graph.execute(query1)
-    
-    # If the function is found continue query
-    if result1: 
-        # Get all instructions that have function name
-        func_addr = int(result1[0]['a']['value'], 16)
-        query2 = 'match $x has operation-type "MLIL_CALL_SSA" has asm-address $a; $y isa"MLIL_CONST_PTR"; ($x,$y); $z isa constant, has constant-value {}; ($y,$z); get $x, $a;'.format(func_addr)
-        result2 = graph.execute(query2)
+    client = grakn.Grakn(uri='localhost:48555')
+    with client.session(keyspace=keyspace).transaction(grakn.TxType.READ) as graph:
+        # Check for gets() function
+        # Get address of function to use for next query
+        func_names = ['gets', 'cgc_gets']
+        func_addrs = []
+        for function_name in func_names:
+            query1 = 'match $func isa function, has func-name "{}", has asm-address $a; get $a;'.format(function_name)
+            func_addrs += [int(result.value(), 16) for result in graph.query(query1).collect_concepts()]
         
-        # If there are instructions that use the function check the instructions 
-        for instr in result2:
-            ins_addr = instr['a']['value']
-            print("CWE-120: Buffer Copy Without Checking Size of Input at {}\n".format(ins_addr))
+        # If the function is found continue query
+        for func_addr in func_addrs:
+            # Get all instructions that have function name
+            query2 = 'match $x has operation-type "MLIL_CALL_SSA" has asm-address $a; $y isa"MLIL_CONST_PTR"; ($x,$y); $z isa constant, has constant-value {}; ($y,$z); get $a;'.format(func_addr)
+            result2 = graph.query(query2).collect_concepts()
+
+            # If there are instructions that use the function check the instructions
+            for instr in result2:
+                ins_addr = instr.value()
+                print("CWE-120: Buffer Copy Without Checking Size of Input at {}".format(ins_addr))
 
 if __name__ == "__main__":
     if len(sys.argv) > 1:

--- a/queries/cwe_121_v1.py
+++ b/queries/cwe_121_v1.py
@@ -6,7 +6,7 @@
 #     (cgc_receive_delim(0, string, 128, '\n') != 0)                <--Bad
 #     (cgc_receive_delim(0, string, sizeof(string), '\n') != 0)     <--Good
 #
-# Methodo#logy: 
+# Methodo#logy:
 # 1. Find all instructions that call a specific function specified with function_name
 # 2. Check these instructions' parameters, string, and bytes allocated (sizeof(string))
 # 3. Find where the string was initialized to get amount of bytes allocated
@@ -14,9 +14,9 @@
 #
 # Try it on: Palindrome2, ShoutCTF
 #
-# Includes functions: 
+# Includes functions:
 # fgets(name, sizeof(name), stdin)
-# receive_delim(0, 0, string, sizeof(string), '\n') 
+# receive_delim(0, 0, string, sizeof(string), '\n')
 # strncpy(targetBuffer, srcBuffer, sizeof(targetBuffer));
 # receive_until(buff, '\n', 25);
 # memcpy(str1, str2, n);
@@ -25,70 +25,71 @@
 #============================================================================================================
 
 import sys
-import grakn 
+import grakn
 
 def main(keyspace):
-    graph = grakn.Client(uri='http://localhost:4567', keyspace=keyspace)
+    client = grakn.Grakn(uri='localhost:48555')
+    with client.session(keyspace=keyspace).transaction(grakn.TxType.READ) as graph:
 
-    # Functions with indexes for (dest, sizeof(dest)) stored in dict
-    functions = {"receive_delim": (2,3), "fgets": (0,1), "strncpy": (0,2), "receive_until": (0,2), "memcpy": (0,2), "freaduntil": (1,2), "read":(1,2)}
-    
-    # Check for potential vuln in each function
-    for function_name in functions:
-       # Get address of function to use for next query
-        query1 = 'match $func isa function, has func-name contains "{}", has asm-address $a; get $a;'.format(function_name)
-        result1 = graph.execute(query1)
-        
-        # If the function is found continue query
-        if result1: 
-            # Get all instructions that have function name
-            func_addr = int(result1[0]['a']['value'], 16)
-            query2 = 'match $x has operation-type "MLIL_CALL_SSA"; $y isa"MLIL_CONST_PTR"; ($x,$y); $z isa constant, has constant-value {}; ($y,$z); get $x;'.format(func_addr)
-            result2 = graph.execute(query2)
-            
-            # If there are instructions that use the function check the instructions 
-            if result2:
+        # Functions with indexes for (dest, sizeof(dest)) stored in dict
+        functions = {"receive_delim": (2,3), "fgets": (0,1), "strncpy": (0,2), "receive_until": (0,2), "memcpy": (0,2), "freaduntil": (1,2), "read":(1,2)}
 
-                buff_index = functions[function_name][0]
-                size_index = functions[function_name][1]
-                for instr in result2:
-                    Id = instr['x']['id']
-                    query3 = 'match $x id "' + Id + '"; $l isa list; ($x,$l); (from-node: $l, $q); $q has edge-label $e; (from-node: $q, $v); {$v has var $s;} or {$v has constant-value $s;}; get $e, $s;'
-                    result3 = graph.execute(query3)
-            
-                    # This section grabs instrution params and insert into an array 
-                    param_array = [0, 0, 0, 0, 0, 0, 0, 0]
+        # Check for potential vuln in each function
+        for function_name in functions:
+        # Get address of function to use for next query
+            query1 = 'match $func isa function, has func-name contains "{}", has asm-address $a; get $a;'.format(function_name)
+            result1 = [result.map() for result in graph.query(query1)]
 
-                    for ele in result3:
-                        index = int(ele['e']['value'])
-                        val = ele['s']['value']
-                        param_array[index] = val
-                    # Get var name - This is done to determine how many bytes the variable is
-                    var_name = param_array[buff_index]
-                    var_name = var_name.split('#',1)[0].lstrip()
+            # If the function is found continue query
+            if result1:
+                # Get all instructions that have function name
+                func_addr = int(result1[0]['a'].value(), 16)
+                query2 = 'match $x has operation-type "MLIL_CALL_SSA"; $y isa"MLIL_CONST_PTR"; ($x,$y); $z isa constant, has constant-value {}; ($y,$z); get $x;'.format(func_addr)
+                result2 = [result.map() for result in graph.query(query2)]
 
-                    # NOTE Enhancement Make finding buff_size the same as string_size
-                    # This assumes that buffer_size is a number, breaks when its a var or register 
-                    # Get buffer size 
-                    try:
-                        buff_size = int(param_array[size_index])
-                    except ValueError as err:
-                        continue
-                    # Get size of string in by finding initialization Ex. var_88 = &var_58        
-                    # Find where string is initialzed
-                    query4 = 'match $x id "{}"; $y isa basic-block; ($x,$y); $z isa instruction, has operation-type "MLIL_SET_VAR_SSA"; ($y,$z); {{$v1 isa variable, has var "{}";}} or {{$v1 isa variable-ssa, has var "{}";}}; ($z, $v1); $w isa MLIL_ADDRESS_OF; ($w, $z); $v isa variable, has var-size $s; ($w, $v); get $s, $x;'.format(Id, var_name, var_name)
-                    result4 = graph.execute(query4)
-                    
-                    if (result4):
-                        string_size = result4[0]['s']['value']
-                        # Finally Determine if buffer size == sizeof(str)
-                        if string_size != buff_size:
-                            instruction_ID = result4[0]['x']['id']
-                            query5 = 'match $i id {}, has asm-address $a; get $a;'.format(instruction_ID)
-                            result5 = graph.execute(query5)
-                            instr_addr = result5[0]['a']['value']
+                # If there are instructions that use the function check the instructions
+                if result2:
 
-                            print("CWE-121: Stack-based Overflow possible at {}".format(instr_addr))
+                    buff_index = functions[function_name][0]
+                    size_index = functions[function_name][1]
+                    for instr in result2:
+                        Id = instr['x'].id
+                        query3 = 'match $x id "' + Id + '"; $l isa list; ($x,$l); (from-node: $l, $q); $q has edge-label $e; (from-node: $q, $v); {$v has var $s;} or {$v has constant-value $s;}; get $e, $s;'
+                        result3 = [result.map() for result in graph.query(query3)]
+
+                        # This section grabs instrution params and insert into an array
+                        param_array = [0, 0, 0, 0, 0, 0, 0, 0]
+
+                        for ele in result3:
+                            index = int(ele['e'].value())
+                            val = ele['s'].value()
+                            param_array[index] = val
+                        # Get var name - This is done to determine how many bytes the variable is
+                        var_name = param_array[buff_index]
+                        var_name = var_name.split('#',1)[0].lstrip()
+
+                        # NOTE Enhancement Make finding buff_size the same as string_size
+                        # This assumes that buffer_size is a number, breaks when its a var or register
+                        # Get buffer size
+                        try:
+                            buff_size = int(param_array[size_index])
+                        except ValueError as err:
+                            continue
+                        # Get size of string in by finding initialization Ex. var_88 = &var_58
+                        # Find where string is initialzed
+                        query4 = 'match $x id "{}"; $y isa basic-block; ($x,$y); $z isa instruction, has operation-type "MLIL_SET_VAR_SSA"; ($y,$z); {{$v1 isa variable, has var "{}";}} or {{$v1 isa variable-ssa, has var "{}";}}; ($z, $v1); $w isa MLIL_ADDRESS_OF; ($w, $z); $v isa variable, has var-size $s; ($w, $v); get $s, $x;'.format(Id, var_name, var_name)
+                        result4 = [result.map() for result in graph.query(query4)]
+
+                        if (result4):
+                            string_size = result4[0]['s'].value()
+                            # Finally Determine if buffer size == sizeof(str)
+                            if string_size != buff_size:
+                                instruction_ID = result4[0]['x'].id
+                                query5 = 'match $i id {}, has asm-address $a; get $a;'.format(instruction_ID)
+                                result5 = [result.map() for result in graph.query(query5)]
+                                instr_addr = result5[0]['a'].value()
+
+                                print("CWE-121: Stack-based Overflow possible at {}".format(instr_addr))
 
 if __name__ == "__main__":
     if len(sys.argv) > 1:

--- a/queries/cwe_129_v1.py
+++ b/queries/cwe_129_v1.py
@@ -3,14 +3,14 @@
 #
 # Vuln Info: This vulnerability comes from using untrusted (unchecked) input when using an array index.
 #
-# Methodology: Find all signed comparisons of a varaible and constant and follow the variable to see if its 
+# Methodology: Find all signed comparisons of a varaible and constant and follow the variable to see if its
 #               other bound is checked.
 #
-# TODO: Currently the script searches out all comparisons to see if the other bound is checked by looking 
-#       for the same variable in other comparisons. The search can be improved by instead searching for where 
+# TODO: Currently the script searches out all comparisons to see if the other bound is checked by looking
+#       for the same variable in other comparisons. The search can be improved by instead searching for where
 #       the user can modify an array index then checking for bounds on that.
 #
-# Limitations: This implementation only find instances where one bound was checked, but not the other. 
+# Limitations: This implementation only find instances where one bound was checked, but not the other.
 #               Also this implementation does not specifically search for array indexs, but comparisons in general.
 #
 # try it on: recipe_and_pantry_manager
@@ -25,63 +25,65 @@ def fail():
 
 #Finds comparisons that are acting as a lower boudns check
 def lowerCheck():
-    query = graph.execute('match {$comp isa MLIL_CMP_SGE;} or {$comp isa MLIL_CMP_SGT;};$node isa MLIL_VAR_SSA;$cons isa MLIL_CONST;($comp, $node);($comp, $cons);$varssa isa variable-ssa has var $var;($node, $varssa);get $comp, $var;') 
-    return query
+    query = 'match {$comp isa MLIL_CMP_SGE;} or {$comp isa MLIL_CMP_SGT;};$node isa MLIL_VAR_SSA;$cons isa MLIL_CONST;($comp, $node);($comp, $cons);$varssa isa variable-ssa has var $var;($node, $varssa);get $comp, $var;'
+    return [result.map() for result in graph.query(query)]
 
 #Finds comparisons that are acting as an upper bounds check
 def upperCheck():
-    query = graph.execute('match {$comp isa MLIL_CMP_SLE;} or {$comp isa MLIL_CMP_SLT;};$node isa MLIL_VAR_SSA;$cons isa MLIL_CONST;($comp, $node);($comp, $cons);$varssa isa variable-ssa has var $var;($node, $varssa);get $comp, $var;') 
-    return query
+    query = 'match {$comp isa MLIL_CMP_SLE;} or {$comp isa MLIL_CMP_SLT;};$node isa MLIL_VAR_SSA;$cons isa MLIL_CONST;($comp, $node);($comp, $cons);$varssa isa variable-ssa has var $var;($node, $varssa);get $comp, $var;'
+    return [result.map() for result in graph.query(query)]
 
 #Returns the addresss of a comparison instruction
 def get_addr(comp):
-    query = graph.execute('match $comp id "' + comp  + '";$inst isa instruction, has asm-address $addr;($comp, $inst);get $addr;')
-    return query
+    query = 'match $comp id "' + comp  + '";$inst isa instruction, has asm-address $addr;($comp, $inst);get $addr;'
+    return [result.map() for result in graph.query(query)]
 
 def main(keyspace):
+    client = grakn.Grakn(uri='localhost:48555')
     global graph
-    graph = grakn.Client(uri='http://localhost:4567', keyspace=keyspace)
+    with client.session(keyspace=keyspace).transaction(grakn.TxType.READ) as graph:
 
-    #Find a variable being compared
-    query1 = graph.execute('match {$comp isa MLIL_CMP_SGE;} or {$comp isa MLIL_CMP_SLE;} or {$comp isa MLIL_CMP_SLT;} or {$comp isa MLIL_CMP_SGT;};$node isa MLIL_VAR_SSA;$cons isa MLIL_CONST;($comp, $node);($comp, $cons);$varssa isa variable-ssa has var $var;($node, $varssa);get $comp, $var;') 
+        #Find a variable being compared
+        query1 = 'match {$comp isa MLIL_CMP_SGE;} or {$comp isa MLIL_CMP_SLE;} or {$comp isa MLIL_CMP_SLT;} or {$comp isa MLIL_CMP_SGT;};$node isa MLIL_VAR_SSA;$cons isa MLIL_CONST;($comp, $node);($comp, $cons);$varssa isa variable-ssa has var $var;($node, $varssa);get $comp, $var;'
+        result1 = [result.map() for result in graph.query(query1)]
 
-    #Parse the output of query1 into the compare statements and varaible names
-    comp, var = [], []
-    if query1:
-        for entry in query1:
-            comp.append(entry['comp']['id'])
-            var.append(entry['var']['value'])
-    else:
-        fail()
-    for entry in comp:
-        #Do upper bound check
-        if ('SGE' or 'SGT') in entry:
-            lower = lowerCheck()
-            if lower:
-                for item in lower:
-                    if item['var']['value'] not in var:
-                        #failed to find upper bound check
-                        addr = get_addr(entry)
-                        print('CWE-129: Missing upper bound check at ' + str(addr[0]['addr']['value']))
-                    else:
-                        adddr = get_addr(entry)
-            else:
-                addr = get_addr(entry)
-                print('CWE-129: Missing upper bound check at ' + str(addr[0]['addr']['value']))
-        #Do lower bound check
+        #Parse the output of result1 into the compare statements and varaible names
+        comp, var = [], []
+        if result1:
+            for entry in result1:
+                comp.append(entry['comp'].id)
+                var.append(entry['var'].value())
         else:
-            upper = upperCheck()
-            if upper:
-                for item in upper:
-                    if item['var']['value'] not in var:
-                        #failed to find lower bound check
-                        addr = get_addr(entry)
-                        print('CWE-129: Missing lower bound check at ' + str(addr[0]['addr']['value']))
-                    else:
-                        addr = get_addr(entry)  
+            fail()
+        for entry in comp:
+            #Do upper bound check
+            if ('SGE' or 'SGT') in entry:
+                lower = lowerCheck()
+                if lower:
+                    for item in lower:
+                        if item['var'].value() not in var:
+                            #failed to find upper bound check
+                            addr = get_addr(entry)
+                            print('CWE-129: Missing upper bound check at ' + str(addr[0]['addr'].value()))
+                        else:
+                            adddr = get_addr(entry)
+                else:
+                    addr = get_addr(entry)
+                    print('CWE-129: Missing upper bound check at ' + str(addr[0]['addr'].value()))
+            #Do lower bound check
             else:
-                addr = get_addr(entry)
-                print('CWE-129: Missing lower bound check at ' + str(addr[0]['addr']['value']))
+                upper = upperCheck()
+                if upper:
+                    for item in upper:
+                        if item['var'].value() not in var:
+                            #failed to find lower bound check
+                            addr = get_addr(entry)
+                            print('CWE-129: Missing lower bound check at ' + str(addr[0]['addr'].value()))
+                        else:
+                            addr = get_addr(entry)
+                else:
+                    addr = get_addr(entry)
+                    print('CWE-129: Missing lower bound check at ' + str(addr[0]['addr'].value()))
 
 if __name__ == "__main__":
     if len(sys.argv) > 1:

--- a/queries/cwe_134_v1.py
+++ b/queries/cwe_134_v1.py
@@ -5,7 +5,7 @@
 # Ex: cgc_printf(message);          <--Bad
 #     cgc_printf("%s", message);    <--Good
 #
-# Methodology: 
+# Methodology:
 # 1. Check if file has a printf function
 # 2. Check if any instructions use printf
 # 3. Check if params in printf are data type(correct) or var_type(incorrect, no modifier i.e. %s used)
@@ -17,29 +17,30 @@ import sys
 import grakn
 
 def main(keyspace):
-    graph = grakn.Client(uri='http://localhost:4567', keyspace=keyspace)
+    client = grakn.Grakn(uri='localhost:48555')
+    with client.session(keyspace=keyspace).transaction(grakn.TxType.READ) as graph:
 
-    # Get address of printf to use for next query
-    query1 ='match $func isa function, has func-name contains "printf", has asm-address $a; offset 0; limit 100; get $a;'
-    result1 = graph.execute(query1)
-    if len(result1) > 0:
-        print("Found potential calls at the following addresses:")
-        for addr in result1:
-            print(addr['a']['value'])
+        # Get address of printf to use for next query
+        query1 ='match $func isa function, has func-name contains "printf", has asm-address $a; offset 0; limit 100; get $a;'
+        result1 = [result.map() for result in graph.query(query1)]
+        if len(result1) > 0:
+            print("Found potential calls at the following addresses:")
+            for addr in result1:
+                print(addr['a'].value())
 
-    # If printf is found continue query
-    for printf_func in result1:
-        # Pull any instructions that use printf and don't use a modifier (have var type and not data type)
-        func_addr = int(printf_func['a']['value'], 16)
-        print("Scanning address {}".format(hex(func_addr)))
-        query2 = 'match $x isa instruction, has operation-type "MLIL_CALL_SSA", has asm-address $a; $y isa "MLIL_CONST_PTR"; ($x,$y); $z isa constant, has constant-value {}; ($y,$z); $l isa list, has list-size 1; ($x,$l); $s isa "MLIL_VAR_SSA"; ($l,$s); offset 0; limit 500; get $x, $a;'.format(func_addr)
-        result2 = graph.execute(query2)
-        
-        # If there is an instruction that uses printf without modifier, output instruction 
-        if result2:
-            for instr in result2:
-                asm_addr = instr['a']['value']
-                print("CWE-134: Uncontrolled Format String possible at {} ".format(asm_addr))
+        # If printf is found continue query
+        for printf_func in result1:
+            # Pull any instructions that use printf and don't use a modifier (have var type and not data type)
+            func_addr = int(printf_func['a'].value(), 16)
+            print("Scanning address {}".format(hex(func_addr)))
+            query2 = 'match $x isa instruction, has operation-type "MLIL_CALL_SSA", has asm-address $a; $y isa "MLIL_CONST_PTR"; ($x,$y); $z isa constant, has constant-value {}; ($y,$z); $l isa list, has list-size 1; ($x,$l); $s isa "MLIL_VAR_SSA"; ($l,$s); offset 0; limit 500; get $x, $a;'.format(func_addr)
+            result2 = [result.map() for result in graph.query(query2)]
+
+            # If there is an instruction that uses printf without modifier, output instruction
+            if result2:
+                for instr in result2:
+                    asm_addr = instr['a'].value()
+                    print("CWE-134: Uncontrolled Format String possible at {} ".format(asm_addr))
 
 if __name__ == "__main__":
     if len(sys.argv) > 1:

--- a/queries/cwe_788_v1.py
+++ b/queries/cwe_788_v1.py
@@ -1,11 +1,11 @@
-#======================================================================================= 
+#=======================================================================================
 # CWE-788: Access of Memory Location After End of Buffer
 #
-# Vuln Info: The software reads or writes to a buffer using an index or pointer that 
+# Vuln Info: The software reads or writes to a buffer using an index or pointer that
 #            references a memory location after the end of the buffer.
-# 
+#
 # Methodology:
-# 1.Find any arrays 
+# 1.Find any arrays
 # 2.Find indexing variables for said arrays
 # 3.Look to see if those variables are used in a comparison (bounds check)
 #=======================================================================================
@@ -20,102 +20,102 @@ def fail():
 
 #Searches for potential array declarations
 def query1():
-    result = graph.execute('match $set isa instruction, has operation-type "MLIL_SET_VAR_SSA";$ptr isa MLIL_CONST_PTR;($set, $ptr);$reg isa variable-ssa, has var $index;($set, $reg); get $index;')
-    return result
+    query = 'match $set isa instruction, has operation-type "MLIL_SET_VAR_SSA";$ptr isa MLIL_CONST_PTR;($set, $ptr);$reg isa variable-ssa, has var $index;($set, $reg); get $index;'
+    return [result.map() for result in graph.query(query)]
 
 #Finds potential loops
 def query2():
-    result = graph.execute('match $block isa basic-block;($block, $inst);$inst isa instruction;$reg isa variable-ssa, has var $index, has edge-label "dest";($inst, $reg);get $index, $block;')
-    return result
+    query = 'match $block isa basic-block;($block, $inst);$inst isa instruction;$reg isa variable-ssa, has var $index, has edge-label "dest";($inst, $reg);get $index, $block;'
+    return [result.map() for result in graph.query(query)]
 
-#Checks query2 for if statements    
+#Checks query2 for if statements
 def query3(item):
-    result = graph.execute('match $block isa basic-block, id "' + item  + '";($block, $inst);$inst isa instruction, has operation-type "MLIL_IF";offset 0; get $inst;')
-    return result
+    query = 'match $block isa basic-block, id "' + item  + '";($block, $inst);$inst isa instruction, has operation-type "MLIL_IF";offset 0; get $inst;'
+    return [result.map() for result in graph.query(query)]
 
-#Finds and returns various information about the loops, including the counting variable 
+#Finds and returns various information about the loops, including the counting variable
 def query4(entry):
-    result = graph.execute('match $block isa basic-block, id "' + entry  + '";($block, contains-instruction:$inst);$inst isa instruction, has operation-type "MLIL_SET_VAR_SSA";($inst, to-node:$add);$add isa MLIL_ADD;$var isa MLIL_VAR_SSA;($add, $var);$const isa MLIL_CONST;($add, $const);$one isa constant has constant-value 1;($const, $one);$reg isa variable-ssa, has var $index, has version $version, has edge-label "dest";($inst, $reg);get $index, $reg, $version;')
-    return result
+    query = 'match $block isa basic-block, id "' + entry  + '";($block, contains-instruction:$inst);$inst isa instruction, has operation-type "MLIL_SET_VAR_SSA";($inst, to-node:$add);$add isa MLIL_ADD;$var isa MLIL_VAR_SSA;($add, $var);$const isa MLIL_CONST;($add, $const);$one isa constant has constant-value 1;($const, $one);$reg isa variable-ssa, has var $index, has version $version, has edge-label "dest";($inst, $reg);get $index, $reg, $version;'
+    return [result.map() for result in graph.query(query)]
 
-#Checks if the bounds on the counting varaible (array index) are ever checked   
+#Checks if the bounds on the counting varaible (array index) are ever checked
 def query5():
-    result = graph.execute('match $block isa basic-block;$inst isa instruction, has operation-type "MLIL_IF";($block, $inst);{$comp isa MLIL_CMP_SGE;} or {$comp isa MLIL_CMP_SLE;} or {$comp isa MLIL_CMP_SLT;} or {$comp isa MLIL_CMP_SGT;} or {$comp isa MLIL_CMP_UGE;} or {$comp isa MLIL_CMP_ULE;} or {$comp isa MLIL_CMP_ULT;} or {$comp isa MLIL_CMP_UGT;};($inst, $comp);$reg isa MLIL_VAR_SSA;($comp, $reg);$index isa variable-ssa, has var $var, has version $version;($reg, $index);get $var, $version;')
-    return result
+    query = 'match $block isa basic-block;$inst isa instruction, has operation-type "MLIL_IF";($block, $inst);{$comp isa MLIL_CMP_SGE;} or {$comp isa MLIL_CMP_SLE;} or {$comp isa MLIL_CMP_SLT;} or {$comp isa MLIL_CMP_SGT;} or {$comp isa MLIL_CMP_UGE;} or {$comp isa MLIL_CMP_ULE;} or {$comp isa MLIL_CMP_ULT;} or {$comp isa MLIL_CMP_UGT;};($inst, $comp);$reg isa MLIL_VAR_SSA;($comp, $reg);$index isa variable-ssa, has var $var, has version $version;($reg, $index);get $var, $version;'
+    return [result.map() for result in graph.query(query)]
 
-#Returns asm-address of vulnerability   
+#Returns asm-address of vulnerability
 def query6(reg_type, reg):
-    result = graph.execute('match $inst isa instruction, has asm-address $adr;$var isa '+ reg_type + ', id "' + reg + '";($inst, $var);get $adr;')
-    return result
+    query = 'match $inst isa instruction, has asm-address $adr;$var isa '+ reg_type + ', id "' + reg + '";($inst, $var);get $adr;'
+    return [result.map() for result in graph.query(query)]
 
 def main(keyspace):
+    client = grakn.Grakn(uri='localhost:48555')
     global graph
-    graph = grakn.Client(uri='http://localhost:4567', keyspace=keyspace)
+    with client.session(keyspace=keyspace).transaction(grakn.TxType.READ) as graph:
 
-    # Find possible arrays
-    array = []
-    q1 = query1()
-    if q1:
-        i = 0
-        for item in q1:
-            array.append(q1[i]['index']['id'])
-            i += 1
-    else:
-        fail()
-
-    # Find loops involving the array
-    block = []
-    q2 = query2()
-    if q2:
-        i = 0
-        for item in q2:
-            if q2[i]['index']['id'] in array:
-                block.append(q2[i]['block']['id'])
-            i += 1
-    else:
-        fail()
-    
-    # Do the 'loop' blocks contain if statements?
-    if_id = []
-    block2 = block.copy()
-    for item in block2:
-        q3 = query3(item)
-        if not q3:
-            block.remove(item)
-
-    # Find the loop counters
-    var, version, var_id, reg, reg_type, block2 = [], [], [], [], [], block.copy()
-    for entry in block2:
-        q4 = query4(entry)
-        if q4:
+        # Find possible arrays
+        array = []
+        q1 = query1()
+        if q1:
             i = 0
-            for item in q4:
-                reg.append(item['reg']['id'])
-                reg_type.append(item['reg']['type']['label'])
-                print(item['reg']['type']['label'])
-                var.append(item['index']['value'])
-                version.append(item['version']['value'])
-                var_id.append(item['index']['id'])
+            for item in q1:
+                array.append(q1[i]['index'].id)
                 i += 1
         else:
-            block.remove(entry)
-    i = len(var) - 1
+            fail()
 
-    # Find is the bounds of the loop counter are checked
-    var2 = []
-    q5 = query5()
-    i = 0
-    for entry in q5:
-        var2.append(q5[i]['var']['value'])
-        i += 1
-    
-    # Any variables in var[] but not var2[] are potential vulnerabilities
-    i = 0
-    for entry in var:
-        if entry not in var2:
-            q6 = query6(reg_type[i], reg[i])
-            print('CWE-788: Array index missing bounds check at ' + q6[0]['adr']['value'] + ' associated with '+ var[i] + '#' + str(version[i]) + ' id = ' + var_id[i] + ' sub of ' + reg_type[i] + ' id = ' + reg[i])
-        i += 1
+        # Find loops involving the array
+        block = []
+        q2 = query2()
+        if q2:
+            i = 0
+            for item in q2:
+                if q2[i]['index'].id in array:
+                    block.append(q2[i]['block'].id)
+                i += 1
+        else:
+            fail()
+
+        # Do the 'loop' blocks contain if statements?
+        if_id = []
+        block2 = block.copy()
+        for item in block2:
+            q3 = query3(item)
+            if not q3:
+                block.remove(item)
+
+        # Find the loop counters
+        var, version, var_id, reg, reg_type, block2 = [], [], [], [], [], block.copy()
+        for entry in block2:
+            q4 = query4(entry)
+            if q4:
+                i = 0
+                for item in q4:
+                    reg.append(item['reg'].id)
+                    reg_type.append(item['reg'].type().label())
+                    var.append(item['index'].value())
+                    version.append(item['version'].value())
+                    var_id.append(item['index'].id)
+                    i += 1
+            else:
+                block.remove(entry)
+        i = len(var) - 1
+
+        # Find is the bounds of the loop counter are checked
+        var2 = []
+        q5 = query5()
+        i = 0
+        for entry in q5:
+            var2.append(q5[i]['var'].value())
+            i += 1
+
+        # Any variables in var[] but not var2[] are potential vulnerabilities
+        i = 0
+        for entry in var:
+            if entry not in var2:
+                q6 = query6(reg_type[i], reg[i])
+                print('CWE-788: Array index missing bounds check at ' + q6[0]['adr'].value() + ' associated with '+ var[i] + '#' + str(version[i]) + ' id = ' + var_id[i] + ' sub of ' + reg_type[i] + ' id = ' + reg[i])
+            i += 1
 
 if __name__ == "__main__":
     if len(sys.argv) > 1:


### PR DESCRIPTION
Fixes #3 

My suggested changes for this PR and the [Dockerize PR](https://github.com/cetfor/PaperMachete/pull/6) are at [https://github.com/devtty1er/PaperMachete.wiki.git](https://github.com/devtty1er/PaperMachete/wiki/Setup) (the links won't work, because they point to the upstream wiki).

Most of the changes were:
```diff
- graph = grakn.Client(uri='http://localhost:4567', keyspace=keyspace)
- some_results = graph.execute('some query; get $x;')
- for some_result in some_results:
-     print(some_result['x']['value'])
+ client = grakn.Grakn(uri='localhost:48555')
+ with client.session(keyspace=keyspace).transaction(grakn.TxType.READ) as graph:
+     some_results = [some_result.map() for some_result in graph.query('some query; get $x')]
+     for some_result in some_results:
+         print(some_result['x'].value())   
```
Using `map()` preserved the syntax of using variable names as keys; however, you could also `collect_concepts()`, particularly for queries of only one variable.

This PR doesn't make any functional changes, except for CWE-120, where I changed `has func-name contains {}` to `has func-name {}`, which fixes the bug where `getsomething()` is treated the same as  `gets()`. The same probably needs to be done for other queries, but I will make those changes in a separate PR once I get the horsepower to [test the challenge binaries](https://github.com/cetfor/PaperMachete/wiki/CGC-Vulnerability-Identification-Progress).